### PR TITLE
Add option to define custom render pass file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,3 @@
 /config.py
 /config.ini
 /config/config.ini
-/python_embeded
-/sequences
-/workflows/sequences
-run.bat

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /config.py
 /config.ini
 /config/config.ini
+/python_embeded
+/sequences
+/workflows/sequences
+run.bat

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def main():
 			print(f"Could not find RenderPassFile: {render_pass_file}")
 			return
 	
-	if not any([c.startswith('RenderPass') for c in config]):
+	if not any([c.startswith("RenderPass") for c in config]):
 		print('No renderpasses found in configuration files.')
 		return
 

--- a/main.py
+++ b/main.py
@@ -49,6 +49,10 @@ def main():
 		else:
 			print(f"Could not find RenderPassFile: {render_pass_file}")
 			return
+	
+	if not any([c.startswith('RenderPass') for c in config]):
+		print('No renderpasses found in configuration files.')
+		return
 
 	if not "VideoDir" in defaults:
 		print(f"Error: Could not find VideoDir in config.")

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ def main():
 		if os.path.isfile(render_pass_file):
 			config.read_string(fix_config(render_pass_file))
 		else:
-			print(f"Could not find RenderPassFile: {defaults.get('RenderPassFile')}")
+			print(f"Could not find RenderPassFile: {render_pass_file}")
 			return
 
 	if not "VideoDir" in defaults:

--- a/main.py
+++ b/main.py
@@ -30,8 +30,8 @@ def fix_config(config):
 	return "".join(lines)
 
 def main():
-	# Start a timer.	
-	start_time = time.time()
+	# Start overall timer.	
+	start_timer = time.time()
 
 	config = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
 
@@ -68,6 +68,7 @@ def main():
 		type = arr[1]
 
 		print(f"Executing pass: {name} ({type})")
+		start_pass_timer = time.time()
 
 		rp_config = config[config_name]
 
@@ -96,10 +97,13 @@ def main():
 
 		if rp_config.getboolean("WaitForUserInput", fallback=False):
 			input("Press enter to continue...")
-	
+
+		pass_timer_obj = datetime.utcfromtimestamp(time.time() - start_pass_timer)
+		print("Pass time:", pass_timer_obj.strftime("%H:%M:%S"))
+
 	print("DONE!")
 	# End timer and display in hours, minutes and seconds.
-	time_obj = datetime.utcfromtimestamp(time.time() - start_time)
+	time_obj = datetime.utcfromtimestamp(time.time() - start_timer)
 	print("Time elapsed:", time_obj.strftime("%H:%M:%S"))
 	return
 

--- a/main.py
+++ b/main.py
@@ -39,12 +39,13 @@ def main():
 	config.read_string(fix_config("config/config.ini"))
 
 	defaults = config["DEFAULT"]
-
+	render_pass_file = defaults.get("RenderPassFile")
+								 
 	if defaults.getboolean("UseExampleRenderPasses"):
 		config.read_string(fix_config("config/example.renderpasses.ini"))
-	elif defaults.get("RenderPassFile"):		
-		if os.path.isfile(defaults.get("RenderPassFile")):
-			config.read_string(fix_config(defaults.get("RenderPassFile")))
+	elif render_pass_file:
+		if os.path.isfile(render_pass_file):
+			config.read_string(fix_config(render_pass_file))
 		else:
 			print(f"Could not find RenderPassFile: {defaults.get('RenderPassFile')}")
 			return


### PR DESCRIPTION
This allows allow a user to define a custom render pass file. This means that user can create their own render pass files instead of editing example.renderpasses.ini, the same way you can define a custom config.ini file.

Tested all four combos - UseExampleRenderPasses yes/no; RenderPassFile commented out/uncommented.

If UseExampleRenderPasses = yes then RenderPassFile ignored. If UseExampleRenderPasses = no and RenderPassFile commented out main() drops through without doing anything. 

Also, added check that file exists. If the render pass file cannot be found there is a graceful exit with message.